### PR TITLE
Speed-up Travis build by caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,6 @@ script:
     if [ ! -e ~/antsbin/ANTs-build ]; then
         if [ ! -e ~/antsbin ]; then mkdir ~/antsbin; fi
         cd ~/antsbin;
-        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_ALL_ANTS_APPS=OFF -DRUN_LONG_TESTS=OFF -DRUN_SHORT_TESTS=OFF ~/ANTs && make -j2 --keep-going
+        cmake -DCMAKE_BUILD_TYPE=Release -DRUN_LONG_TESTS=OFF -DRUN_SHORT_TESTS=OFF ~/ANTs && make -j2 --keep-going
     fi
   - cd ~/build/UCL/petmr-RESOLUTE && cmake -DCMAKE_BUILD_TYPE=Release -DITK_DIR=~/antsbin/ITKv4-build -DANTs_SOURCE_DIR=~/ANTs -DANTs_LIBRARY_DIR=~/antsbin/lib && make -j2


### PR DESCRIPTION
Switches off ANTs tests to reduce build time for gcc on Linux.
